### PR TITLE
Add binstaller configuration

### DIFF
--- a/.config/binstaller.yml
+++ b/.config/binstaller.yml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/binary-install/binstaller/main/schema/InstallSpec.json
+schema: v1
+name: semver
+repo: binary-install/semver
+asset:
+  template: ${NAME}_${OS}_${ARCH}${EXT}
+  default_extension: .tar.gz
+  rules:
+  - when:
+      arch: amd64
+    arch: x86_64
+  - when:
+      arch: "386"
+    arch: i386
+  - when:
+      os: windows
+    ext: .zip
+  naming_convention:
+    os: lowercase
+    arch: lowercase
+checksums:
+  algorithm: sha256
+  template: checksums.txt
+supported_platforms:
+- os: darwin
+  arch: amd64
+- os: darwin
+  arch: arm64
+- os: linux
+  arch: "386"
+- os: linux
+  arch: amd64
+- os: linux
+  arch: arm64
+- os: windows
+  arch: "386"
+- os: windows
+  arch: amd64
+- os: windows
+  arch: arm64


### PR DESCRIPTION
## Summary
- Add binstaller configuration file (`.config/binstaller.yml`)
- Generated from existing GoReleaser configuration
- Enables easy installation of semver CLI tool

## Description

This PR adds a binstaller configuration that allows users to easily install the semver CLI tool using the [binstaller](https://github.com/binary-install/binstaller) tool.

The configuration was automatically generated from the existing `.goreleaser.yml` file and supports all platforms:
- **Linux**: amd64, 386, arm64
- **macOS**: amd64, arm64  
- **Windows**: amd64, 386, arm64

## Usage

With this configuration, users can install semver using:

```bash
# Generate and run installer
binst gen -c https://raw.githubusercontent.com/binary-install/semver/main/.config/binstaller.yml | sh

# Or clone repo and run locally
binst gen -c .config/binstaller.yml | sh
```

## Test plan
- [x] Generated config using `binst init --source=goreleaser --file=.goreleaser.yml --repo=binary-install/semver`
- [x] Validated config with `binst check` - all assets exist
- [x] Tested installer script generation with `binst gen`
- [x] Ran dry-run installation `sh install.sh -n` - successful

🤖 Generated with [Claude Code](https://claude.ai/code)